### PR TITLE
SSL.Context: Add support for TLSv1.1 and TLSv1.2; disable SSLv3.

### DIFF
--- a/M2Crypto/SSL/Context.py
+++ b/M2Crypto/SSL/Context.py
@@ -37,6 +37,21 @@ class Context:
     m2_ssl_ctx_free = m2.ssl_ctx_free
 
     def __init__(self, protocol='sslv23', weak_crypto=None):
+        """Construct a new Context object.
+
+        @param protocol:    SSL/TLS version to use. Defaults to "sslv23" which
+                            will allow any of TLSv1, TLSv1.1 and TLSv1.2 by
+                            default. Valid values are:
+                            "sslv2", "sslv23", "sslv3",
+                            "tlsv1", "tlsv1_1", "tlsv1_2".
+        @type protocol:     string
+        @param weak_crypto: By default, SSLv2, SSLv3 and a list of "weak"
+                            ciphers are disabled when using protocol="sslv23".
+                            If this parameter is non-None, protocol="sslv23"
+                            will also allow SSLv2 are SSLv3, and all of
+                            OpenSSL's ciphers are enabled regardless of
+                            protocol.
+        """
         proto = getattr(m2, protocol + '_method', None)
         if proto is None:
             raise ValueError, "no such protocol '%s'" % protocol
@@ -46,7 +61,9 @@ class Context:
         m2.ssl_ctx_set_cache_size(self.ctx, 128L)
         if weak_crypto is None:
             if protocol == 'sslv23':
-                self.set_options(m2.SSL_OP_ALL | m2.SSL_OP_NO_SSLv2)
+                self.set_options(m2.SSL_OP_ALL
+                        | m2.SSL_OP_NO_SSLv2
+                        | m2.SSL_OP_NO_SSLv3)
             self.set_cipher_list('ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH')
         
     def __del__(self):

--- a/SWIG/_ssl.i
+++ b/SWIG/_ssl.i
@@ -54,6 +54,10 @@ extern SSL_METHOD *SSLv3_method(void);
 extern SSL_METHOD *SSLv23_method(void);
 %rename(tlsv1_method) TLSv1_method;
 extern SSL_METHOD *TLSv1_method(void);
+%rename(tlsv1_1_method) TLSv1_1_method;
+extern SSL_METHOD *TLSv1_1_method(void);
+%rename(tlsv1_2_method) TLSv1_2_method;
+extern SSL_METHOD *TLSv1_2_method(void);
 
 %rename(ssl_ctx_new) SSL_CTX_new;
 extern SSL_CTX *SSL_CTX_new(SSL_METHOD *);


### PR DESCRIPTION
This patch adds support for the TLSv1_1 and TLSv1_2 "methods". It also
documents the "protocol" argument of the Context() constructor,
especially documenting the non-obvious "sslv23" behavior. Last, since
SSLv3 has to be considered insecure at this point, this patch disables
it per default, analogous to the way that SSLv2 is treated.