### PR TITLE
Travis: speedup builds with new container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: python
+sudo: false
 
 python:
   - 2.6
   - 2.7
 
+addons:
+  apt:
+    packages:
+      - libssl0.9.8
+      - libssl-dev
+      - swig
+
 install:
-  - sudo apt-get install swig libssl-dev libssl0.9.8
   - python setup.py install
 
 script: python setup.py test


### PR DESCRIPTION
Travis has a container based infrastructure which is faster to startup. It doesn't allow sudo, but with the apt addon we don't need sudo.

The build still fails due to a missing `tests/test_asn1.py`, but it would do so regardless of this patch.

Example build: https://travis-ci.org/moreati/M2Crypto/builds/73453233
Example badge: [![Build Status](https://travis-ci.org/moreati/M2Crypto.svg?branch=travis_speedup)](https://travis-ci.org/moreati/M2Crypto)

See
 - http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 - http://docs.travis-ci.com/user/apt/