### PR TITLE
Update unit tests to reflect move from tests/ to test/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 /M2Crypto.egg-info
 /EGG-INFO
 *.so
-tests/randpool.dat
-tests/sig.p7
-tests/sig.p7s
+test/randpool.dat
+test/sig.p7
+test/sig.p7s

--- a/examples/tinderbox/slave.py
+++ b/examples/tinderbox/slave.py
@@ -21,7 +21,7 @@ name = identify your build slave, for example Ubuntu 8.04 32-bit
 ;;patch = 
 ;;build = python setup.py clean --all build
 ;; OR another way to do tests without setuptools:
-;;build = PYTHONPATH=build/lib-something python tests/alltests.py
+;;build = PYTHONPATH=build/lib-something python test/alltests.py
 ;;test = python setup.py test
 ;;wait = 3600
 ;;timeout = 180

--- a/test/alltests.py
+++ b/test/alltests.py
@@ -19,34 +19,34 @@ def suite():
         return mod
 
     modules_to_test = [
-        'tests.test_asn1',
-        'tests.test_bio',
-        'tests.test_bio_membuf',
-        'tests.test_bio_file',
-        'tests.test_bio_iobuf',
-        'tests.test_bio_ssl',
-        'tests.test_bn',
-        'tests.test_authcookie',
-        'tests.test_dh',
-        'tests.test_dsa',
-        'tests.test_engine',
-        'tests.test_evp',
-        'tests.test_obj',
-        'tests.test_rand',
-        'tests.test_rc4',
-        'tests.test_rsa',
-        'tests.test_smime',
-        'tests.test_ssl_offline',
-        'tests.test_threading',
-        'tests.test_x509']
+        'test.test_asn1',
+        'test.test_bio',
+        'test.test_bio_membuf',
+        'test.test_bio_file',
+        'test.test_bio_iobuf',
+        'test.test_bio_ssl',
+        'test.test_bn',
+        'test.test_authcookie',
+        'test.test_dh',
+        'test.test_dsa',
+        'test.test_engine',
+        'test.test_evp',
+        'test.test_obj',
+        'test.test_rand',
+        'test.test_rc4',
+        'test.test_rsa',
+        'test.test_smime',
+        'test.test_ssl_offline',
+        'test.test_threading',
+        'test.test_x509']
     if os.name == 'posix':
-        modules_to_test.append('tests.test_ssl')
+        modules_to_test.append('test.test_ssl')
     elif os.name == 'nt':
-        modules_to_test.append('tests.test_ssl_win')
+        modules_to_test.append('test.test_ssl_win')
     if m2.OPENSSL_VERSION_NUMBER >= 0x90800F and m2.OPENSSL_NO_EC == 0:
-        modules_to_test.append('tests.test_ecdh')
-        modules_to_test.append('tests.test_ecdsa')
-        modules_to_test.append('tests.test_ec_curves')
+        modules_to_test.append('test.test_ecdh')
+        modules_to_test.append('test.test_ecdsa')
+        modules_to_test.append('test.test_ec_curves')
     alltests = unittest.TestSuite()
     for module in map(my_import, modules_to_test):
         alltests.addTest(module.suite())
@@ -83,9 +83,9 @@ def runall(report_leaks=0):
     from M2Crypto import Rand
     
     try:
-        Rand.load_file('tests/randpool.dat', -1) 
+        Rand.load_file('test/randpool.dat', -1)
         unittest.TextTestRunner(verbosity=2).run(suite())
-        Rand.save_file('tests/randpool.dat')
+        Rand.save_file('test/randpool.dat')
     finally:
         if os.name == 'posix':
             from test_ssl import zap_servers

--- a/test/test_bio_ssl.py
+++ b/test/test_bio_ssl.py
@@ -22,7 +22,7 @@ class HandshakeClient(threading.Thread):
         
     def run(self):
         ctx = SSL.Context()
-        ctx.load_cert_chain("tests/server.pem") 
+        ctx.load_cert_chain("test/server.pem")
         conn = SSL.Connection(ctx)
         cipher_list = conn.get_cipher_list()
         sslbio = BIO.SSLBio()
@@ -105,7 +105,7 @@ class SSLTestCase(unittest.TestCase):
    
     def test_do_handshake_succeed(self): # XXX leaks 196/26586 bytes
         ctx = SSL.Context() 
-        ctx.load_cert_chain("tests/server.pem")
+        ctx.load_cert_chain("test/server.pem")
         conn = SSL.Connection(ctx) 
         self.sslbio.set_ssl(conn)
         readbio = BIO.MemoryBuffer()

--- a/test/test_dh.py
+++ b/test/test_dh.py
@@ -8,9 +8,6 @@ import unittest
 from M2Crypto import DH, BIO, Rand, m2
 
 class DHTestCase(unittest.TestCase):
-
-    params = 'tests/dhparam.pem'
-
     def genparam_callback(self, *args):
         pass 
 
@@ -37,11 +34,11 @@ class DHTestCase(unittest.TestCase):
         assert params.find('generator: 2 (0x2)')
 
     def test_load_params(self):
-        a = DH.load_params('tests/dhparams.pem')
+        a = DH.load_params('test/dhparams.pem')
         assert a.check_params() == 0
 
     def test_compute_key(self):
-        a = DH.load_params('tests/dhparams.pem')
+        a = DH.load_params('test/dhparams.pem')
         b = DH.set_params(a.p, a.g)
         a.gen_key()
         b.gen_key()

--- a/test/test_dsa.py
+++ b/test/test_dsa.py
@@ -10,10 +10,10 @@ from M2Crypto import DSA, BIO, Rand, m2
 
 class DSATestCase(unittest.TestCase):
 
-    errkey  = 'tests/rsa.priv.pem'
-    privkey = 'tests/dsa.priv.pem'
-    pubkey  = 'tests/dsa.pub.pem'
-    param   = 'tests/dsa.param.pem'
+    errkey  = 'test/rsa.priv.pem'
+    privkey = 'test/dsa.priv.pem'
+    pubkey  = 'test/dsa.pub.pem'
+    param   = 'test/dsa.param.pem'
 
     data = sha.sha('Can you spell subliminal channel?').digest()
     different_data = sha.sha('I can spell.').digest()

--- a/test/test_ecdh.py
+++ b/test/test_ecdh.py
@@ -13,7 +13,7 @@ import sys
 
 class ECDHTestCase(unittest.TestCase):
 
-    privkey = 'tests/ec.priv.pem'
+    privkey = 'test/ec.priv.pem'
 
     def test_init_junk(self):
         self.assertRaises(TypeError, EC.EC, 'junk')

--- a/test/test_ecdsa.py
+++ b/test/test_ecdsa.py
@@ -12,9 +12,9 @@ from M2Crypto import EC, BIO, Rand, m2
 
 class ECDSATestCase(unittest.TestCase):
 
-    errkey = 'tests/rsa.priv.pem'
-    privkey = 'tests/ec.priv.pem'
-    pubkey = 'tests/ec.pub.pem'
+    errkey = 'test/rsa.priv.pem'
+    privkey = 'test/ec.priv.pem'
+    pubkey = 'test/ec.pub.pem'
 
     data = sha.sha('Can you spell subliminal channel?').digest()
 

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -7,7 +7,7 @@ from M2Crypto import Engine, m2
 
 class EngineTestCase(unittest.TestCase):
 
-    privkey = 'tests/rsa.priv.pem'
+    privkey = 'test/rsa.priv.pem'
     bad_id = '1bea1edfeb97'
 
     def tearDown(self):

--- a/test/test_evp.py
+++ b/test/test_evp.py
@@ -138,27 +138,27 @@ class EVPTestCase(unittest.TestCase):
         
     def test_verify_final(self):
         from M2Crypto import X509
-        pkey = EVP.load_key('tests/signer_key.pem')
+        pkey = EVP.load_key('test/signer_key.pem')
         pkey.sign_init()
         pkey.sign_update('test  message')
         sig = pkey.sign_final()
         
         # OK
-        x509 = X509.load_cert('tests/signer.pem')
+        x509 = X509.load_cert('test/signer.pem')
         pubkey = x509.get_pubkey()
         pubkey.verify_init()
         pubkey.verify_update('test  message')
         assert pubkey.verify_final(sig) == 1
         
         # wrong cert
-        x509 = X509.load_cert('tests/x509.pem')
+        x509 = X509.load_cert('test/x509.pem')
         pubkey = x509.get_pubkey()
         pubkey.verify_init()
         pubkey.verify_update('test  message')
         assert pubkey.verify_final(sig) == 0
         
         # wrong message
-        x509 = X509.load_cert('tests/signer.pem')
+        x509 = X509.load_cert('test/signer.pem')
         pubkey = x509.get_pubkey()
         pubkey.verify_init()
         pubkey.verify_update('test  message not')
@@ -168,7 +168,7 @@ class EVPTestCase(unittest.TestCase):
         self.assertRaises(BIO.BIOError, EVP.load_key,
                           'thisdoesnotexist-dfgh56789')
         self.assertRaises(EVP.EVPError, EVP.load_key,
-                          'tests/signer.pem') # not a key
+                          'test/signer.pem') # not a key
         self.assertRaises(EVP.EVPError, EVP.load_key_bio,
                           BIO.MemoryBuffer('no a key'))
 

--- a/test/test_rand.py
+++ b/test/test_rand.py
@@ -24,12 +24,12 @@ class RandTestCase(unittest.TestCase):
         
     def test_load_save(self):
         try:
-            os.remove('tests/randpool.dat')
+            os.remove('test/randpool.dat')
         except OSError:
             pass
-        assert Rand.load_file('tests/randpool.dat', -1) == 0
-        assert Rand.save_file('tests/randpool.dat') == 1024
-        assert Rand.load_file('tests/randpool.dat', -1) == 1024
+        assert Rand.load_file('test/randpool.dat', -1) == 0
+        assert Rand.save_file('test/randpool.dat') == 1024
+        assert Rand.load_file('test/randpool.dat', -1) == 1024
         
     def test_seed_add(self):
         if sys.version_info >= (2, 4):

--- a/test/test_rsa.py
+++ b/test/test_rsa.py
@@ -10,10 +10,10 @@ from M2Crypto import RSA, BIO, Rand, m2, EVP, X509
 
 class RSATestCase(unittest.TestCase):
 
-    errkey = 'tests/dsa.priv.pem'
-    privkey = 'tests/rsa.priv.pem'
-    privkey2 = 'tests/rsa.priv2.pem'
-    pubkey = 'tests/rsa.pub.pem'
+    errkey = 'test/dsa.priv.pem'
+    privkey = 'test/rsa.priv.pem'
+    privkey2 = 'test/rsa.priv2.pem'
+    pubkey = 'test/rsa.pub.pem'
 
     data = sha.sha('The magic words are squeamish ossifrage.').digest()
 
@@ -107,7 +107,7 @@ class RSATestCase(unittest.TestCase):
         self.assertRaises(TypeError, priv.public_encrypt, self.gen_callback, RSA.pkcs1_padding)
 
     def test_x509_public_encrypt(self):
-        x509 = X509.load_cert("tests/recipient.pem")
+        x509 = X509.load_cert("test/recipient.pem")
         rsa = x509.get_pubkey().get_rsa()
         rsa.public_encrypt("data", RSA.pkcs1_padding)
         
@@ -126,7 +126,7 @@ class RSATestCase(unittest.TestCase):
     def test_savepub(self):
         rsa = RSA.load_pub_key(self.pubkey)
         assert rsa.as_pem() # calls save_key_bio
-        f = 'tests/rsa_test.pub'
+        f = 'test/rsa_test.pub'
         try:
             self.assertEquals(rsa.save_key(f), 1)
         finally:

--- a/test/test_smime.py
+++ b/test/test_smime.py
@@ -19,14 +19,14 @@ class SMIMETestCase(unittest.TestCase):
     def test_load_bad(self):
         s = SMIME.SMIME()
         self.assertRaises(EVP.EVPError, s.load_key,
-                          'tests/signer.pem',
-                          'tests/signer.pem')
+                          'test/signer.pem',
+                          'test/signer.pem')
 
         self.assertRaises(BIO.BIOError, SMIME.load_pkcs7, 'nosuchfile-dfg456')
-        self.assertRaises(SMIME.PKCS7_Error, SMIME.load_pkcs7, 'tests/signer.pem')
+        self.assertRaises(SMIME.PKCS7_Error, SMIME.load_pkcs7, 'test/signer.pem')
         self.assertRaises(SMIME.PKCS7_Error, SMIME.load_pkcs7_bio, BIO.MemoryBuffer('no pkcs7'))
 
-        self.assertRaises(SMIME.SMIME_Error, SMIME.smime_load_pkcs7, 'tests/signer.pem')
+        self.assertRaises(SMIME.SMIME_Error, SMIME.smime_load_pkcs7, 'test/signer.pem')
         self.assertRaises(SMIME.SMIME_Error, SMIME.smime_load_pkcs7_bio, BIO.MemoryBuffer('no pkcs7'))
 
     def test_crlf(self):
@@ -36,7 +36,7 @@ class SMIMETestCase(unittest.TestCase):
     def test_sign(self):
         buf = BIO.MemoryBuffer(self.cleartext)
         s = SMIME.SMIME()
-        s.load_key('tests/signer_key.pem', 'tests/signer.pem')
+        s.load_key('test/signer_key.pem', 'test/signer.pem')
         p7 = s.sign(buf, SMIME.PKCS7_DETACHED)
         assert len(buf) == 0
         assert p7.type() == SMIME.PKCS7_SIGNED, p7.type()
@@ -56,19 +56,19 @@ class SMIMETestCase(unittest.TestCase):
 
     def test_store_load_info(self):        
         st = X509.X509_Store()
-        self.assertRaises(X509.X509Error, st.load_info, 'tests/ca.pem-typoname')
-        self.assertEqual(st.load_info('tests/ca.pem'), 1) 
+        self.assertRaises(X509.X509Error, st.load_info, 'test/ca.pem-typoname')
+        self.assertEqual(st.load_info('test/ca.pem'), 1)
 
     def test_verify(self):
         s = SMIME.SMIME()
         
-        x509 = X509.load_cert('tests/signer.pem')
+        x509 = X509.load_cert('test/signer.pem')
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)
         
         st = X509.X509_Store()
-        st.load_info('tests/ca.pem')
+        st.load_info('test/ca.pem')
         s.set_x509_store(st)
         
         p7, data = SMIME.smime_load_pkcs7_bio(self.signed)
@@ -84,13 +84,13 @@ class SMIMETestCase(unittest.TestCase):
     def test_verifyBad(self):
         s = SMIME.SMIME()
         
-        x509 = X509.load_cert('tests/recipient.pem')
+        x509 = X509.load_cert('test/recipient.pem')
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)
         
         st = X509.X509_Store()
-        st.load_info('tests/recipient.pem')
+        st.load_info('test/recipient.pem')
         s.set_x509_store(st)
         
         p7, data = SMIME.smime_load_pkcs7_bio(self.signed)
@@ -101,7 +101,7 @@ class SMIMETestCase(unittest.TestCase):
         buf = BIO.MemoryBuffer(self.cleartext)
         s = SMIME.SMIME()
 
-        x509 = X509.load_cert('tests/recipient.pem')
+        x509 = X509.load_cert('test/recipient.pem')
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)
@@ -130,7 +130,7 @@ class SMIMETestCase(unittest.TestCase):
     def test_decrypt(self):
         s = SMIME.SMIME()
 
-        s.load_key('tests/recipient_key.pem', 'tests/recipient.pem')
+        s.load_key('test/recipient_key.pem', 'test/recipient.pem')
         
         p7, data = SMIME.smime_load_pkcs7_bio(self.encrypted)
         assert isinstance(p7, SMIME.PKCS7), p7
@@ -142,7 +142,7 @@ class SMIMETestCase(unittest.TestCase):
     def test_decryptBad(self):
         s = SMIME.SMIME()
 
-        s.load_key('tests/signer_key.pem', 'tests/signer.pem')
+        s.load_key('test/signer_key.pem', 'test/signer.pem')
         
         p7, data = SMIME.smime_load_pkcs7_bio(self.encrypted)
         assert isinstance(p7, SMIME.PKCS7), p7
@@ -155,11 +155,11 @@ class SMIMETestCase(unittest.TestCase):
         # sign
         buf = BIO.MemoryBuffer(self.cleartext)
         s = SMIME.SMIME()    
-        s.load_key('tests/signer_key.pem', 'tests/signer.pem')
+        s.load_key('test/signer_key.pem', 'test/signer.pem')
         p7 = s.sign(buf)
         
         # encrypt
-        x509 = X509.load_cert('tests/recipient.pem')
+        x509 = X509.load_cert('test/recipient.pem')
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)
@@ -177,20 +177,20 @@ class SMIMETestCase(unittest.TestCase):
         # decrypt
         s = SMIME.SMIME()
     
-        s.load_key('tests/recipient_key.pem', 'tests/recipient.pem')
+        s.load_key('test/recipient_key.pem', 'test/recipient.pem')
         
         p7, data = SMIME.smime_load_pkcs7_bio(signedEncrypted)
         
         out = s.decrypt(p7)
         
         # verify
-        x509 = X509.load_cert('tests/signer.pem')
+        x509 = X509.load_cert('test/signer.pem')
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)
         
         st = X509.X509_Store()
-        st.load_info('tests/ca.pem')
+        st.load_info('test/ca.pem')
         s.set_x509_store(st)
         
         p7_bio = BIO.MemoryBuffer(out)
@@ -202,15 +202,15 @@ class SMIMETestCase(unittest.TestCase):
 class WriteLoadTestCase(unittest.TestCase):
     def setUp(self):
         s = SMIME.SMIME()
-        s.load_key('tests/signer_key.pem', 'tests/signer.pem')
+        s.load_key('test/signer_key.pem', 'test/signer.pem')
         p7 = s.sign(BIO.MemoryBuffer('some text'))
-        self.filename = 'tests/sig.p7'
+        self.filename = 'test/sig.p7'
         f = BIO.openfile(self.filename, 'wb')
         assert p7.write(f) == 1
         f.close()
 
         p7 = s.sign(BIO.MemoryBuffer('some text'), SMIME.PKCS7_DETACHED)
-        self.filenameSmime = 'tests/sig.p7s'
+        self.filenameSmime = 'test/sig.p7s'
         f = BIO.openfile(self.filenameSmime, 'wb')
         assert s.write(f, p7, BIO.MemoryBuffer('some text')) == 1
         f.close()

--- a/test/test_ssl.py
+++ b/test/test_ssl.py
@@ -84,7 +84,7 @@ class BaseSSLClientTestCase(unittest.TestCase):
         if pid == 0:
             # openssl must be started in the tests directory for it
             # to find the .pem files
-            os.chdir('tests')
+            os.chdir('test')
             try:
                 os.execvp('openssl', args)
             finally:
@@ -149,8 +149,8 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
         try:
             from M2Crypto import httpslib
             ctx = SSL.Context()
-            ctx.load_verify_locations(cafile='tests/ca.pem')
-            ctx.load_cert('tests/x509.pem')
+            ctx.load_verify_locations(cafile='test/ca.pem')
+            ctx.load_cert('test/x509.pem')
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 1)
             ctx.set_session_cache_mode(m2.SSL_SESS_CACHE_CLIENT)
             c = httpslib.HTTPSConnection(srv_host, srv_port, ssl_context=ctx)
@@ -162,8 +162,8 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
             # c.close()
             
             ctx2 = SSL.Context()
-            ctx2.load_verify_locations(cafile='tests/ca.pem')
-            ctx2.load_cert('tests/x509.pem')
+            ctx2.load_verify_locations(cafile='test/ca.pem')
+            ctx2.load_cert('test/x509.pem')
             ctx2.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 1)
             ctx2.set_session_cache_mode(m2.SSL_SESS_CACHE_CLIENT)
             c2 = httpslib.HTTPSConnection(srv_host, srv_port, ssl_context=ctx2)
@@ -185,7 +185,7 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
             from M2Crypto import httpslib
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             c = httpslib.HTTPSConnection(srv_host, srv_port, ssl_context=ctx)
             c.request('GET', '/')
             data = c.getresponse().read()
@@ -200,7 +200,7 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
             from M2Crypto import httpslib
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/server.pem')
+            ctx.load_verify_locations('test/server.pem')
             c = httpslib.HTTPSConnection(srv_host, srv_port, ssl_context=ctx)
             self.assertRaises(SSL.SSLError, c.request, 'GET', '/')
             c.close()
@@ -231,7 +231,7 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
             from M2Crypto import httpslib
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             c = httpslib.HTTPS(srv_host, srv_port, ssl_context=ctx)
             c.putrequest('GET', '/')
             c.putheader('Accept', 'text/html')
@@ -252,7 +252,7 @@ class HttpslibSSLClientTestCase(BaseSSLClientTestCase):
             from M2Crypto import httpslib
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/server.pem')
+            ctx.load_verify_locations('test/server.pem')
             c = httpslib.HTTPS(srv_host, srv_port, ssl_context=ctx)
             c.putrequest('GET', '/')
             c.putheader('Accept', 'text/html')
@@ -293,7 +293,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             s = SSL.Connection(ctx)
             s.connect(self.srv_addr)
             data = self.http_get(s)
@@ -307,7 +307,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/server.pem')
+            ctx.load_verify_locations('test/server.pem')
             s = SSL.Connection(ctx)
             self.assertRaises(SSL.SSLError, s.connect, self.srv_addr)
             s.close()
@@ -648,7 +648,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             s = SSL.Connection(ctx)
             try:
                 s.connect(self.srv_addr)
@@ -665,7 +665,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/server.pem')
+            ctx.load_verify_locations('test/server.pem')
             s = SSL.Connection(ctx)
             self.assertRaises(SSL.SSLError, s.connect, self.srv_addr)
             s.close()
@@ -678,8 +678,8 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
-            ctx.load_cert('tests/x509.pem')
+            ctx.load_verify_locations('test/ca.pem')
+            ctx.load_cert('test/x509.pem')
             s = SSL.Connection(ctx)
             try:
                 s.connect(self.srv_addr)
@@ -697,8 +697,8 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
-            ctx.load_cert('tests/x509.pem')
+            ctx.load_verify_locations('test/ca.pem')
+            ctx.load_cert('test/x509.pem')
             s = SSL.Connection(ctx)
             try:
                 s.connect(self.srv_addr)
@@ -716,7 +716,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             s = SSL.Connection(ctx)
             self.assertRaises(SSL.SSLError, s.connect, self.srv_addr)
             s.close()
@@ -729,7 +729,7 @@ class MiscSSLClientTestCase(BaseSSLClientTestCase):
         try:
             ctx = SSL.Context()
             ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-            ctx.load_verify_locations('tests/ca.pem')
+            ctx.load_verify_locations('test/ca.pem')
             s = SSL.Connection(ctx)
             self.assertRaises(SSL.SSLError, s.connect, self.srv_addr)
             s.close()
@@ -864,7 +864,7 @@ class Urllib2SSLClientTestCase(BaseSSLClientTestCase):
             try:
                 ctx = SSL.Context()
                 ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-                ctx.load_verify_locations('tests/ca.pem')
+                ctx.load_verify_locations('test/ca.pem')
                 
                 from M2Crypto import m2urllib2
                 opener = m2urllib2.build_opener(ctx)
@@ -881,7 +881,7 @@ class Urllib2SSLClientTestCase(BaseSSLClientTestCase):
             try:
                 ctx = SSL.Context()
                 ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-                ctx.load_verify_locations('tests/server.pem')
+                ctx.load_verify_locations('test/server.pem')
                 
                 from M2Crypto import m2urllib2
                 opener = m2urllib2.build_opener(ctx)
@@ -998,7 +998,7 @@ class FtpsLibTestCase(unittest.TestCase):
 class SessionTestCase(unittest.TestCase):
     def test_session_load_bad(self):
         self.assertRaises(SSL.SSLError, SSL.Session.load_session,
-                          'tests/signer.pem')
+                          'test/signer.pem')
 
 class FtpslibTestCase(unittest.TestCase):
     def test_26_compat(self):

--- a/test/test_ssl_offline.py
+++ b/test/test_ssl_offline.py
@@ -17,7 +17,7 @@ class CheckerTestCase(unittest.TestCase):
 
         check = Checker.Checker(host=srv_host,
                                 peerCertHash='CE15B128975EF740A593C4FD08717681A5229BF6')
-        x509 = X509.load_cert('tests/server.pem')
+        x509 = X509.load_cert('test/server.pem')
         assert check(x509, srv_host)
         self.assertRaises(Checker.WrongHost, check, x509, 'example.com')
         
@@ -40,8 +40,8 @@ class ContextTestCase(unittest.TestCase):
     def test_certstore(self):
         ctx = SSL.Context()
         ctx.set_verify(SSL.verify_peer | SSL.verify_fail_if_no_peer_cert, 9)
-        ctx.load_verify_locations('tests/ca.pem')
-        ctx.load_cert('tests/x509.pem')
+        ctx.load_verify_locations('test/ca.pem')
+        ctx.load_cert('test/x509.pem')
 
         store = ctx.get_cert_store()
         assert isinstance(store, X509.X509_Store)

--- a/test/test_ssl_win.py
+++ b/test/test_ssl_win.py
@@ -40,7 +40,7 @@ if win32process:
         def start_server(self, args):
             # openssl must be started in the tests directory for it
             # to find the .pem files
-            os.chdir('tests')        
+            os.chdir('test')
             try:
                 hproc, hthread, pid, tid = win32process.CreateProcess(self.openssl,
                     string.join(args), None, None, 0, win32process.DETACHED_PROCESS, 

--- a/test/test_x509.py
+++ b/test/test_x509.py
@@ -149,16 +149,16 @@ class X509TestCase(unittest.TestCase):
 
     def test_mkreq(self):
         (req, _) = self.mkreq(1024)
-        req.save_pem('tests/tmp_request.pem')
-        req2 = X509.load_request('tests/tmp_request.pem')
-        os.remove('tests/tmp_request.pem')
-        req.save('tests/tmp_request.pem')
-        req3 = X509.load_request('tests/tmp_request.pem')
-        os.remove('tests/tmp_request.pem')
-        req.save('tests/tmp_request.der', format=X509.FORMAT_DER)
-        req4 = X509.load_request('tests/tmp_request.der',
+        req.save_pem('test/tmp_request.pem')
+        req2 = X509.load_request('test/tmp_request.pem')
+        os.remove('test/tmp_request.pem')
+        req.save('test/tmp_request.pem')
+        req3 = X509.load_request('test/tmp_request.pem')
+        os.remove('test/tmp_request.pem')
+        req.save('test/tmp_request.der', format=X509.FORMAT_DER)
+        req4 = X509.load_request('test/tmp_request.der',
                 format=X509.FORMAT_DER)
-        os.remove('tests/tmp_request.der')
+        os.remove('test/tmp_request.der')
         assert req.as_pem() == req2.as_pem()
         assert req.as_text() == req2.as_text()
         assert req.as_der() == req2.as_der()
@@ -338,37 +338,37 @@ class X509TestCase(unittest.TestCase):
         return proxycert
     
     def test_fingerprint(self):
-        x509 = X509.load_cert('tests/x509.pem')
+        x509 = X509.load_cert('test/x509.pem')
         fp = x509.get_fingerprint('sha1')
         expected = '7B8D34D23BF755BE23891AF4CAA0A9868F4C65AD'
         assert fp == expected, '%s != %s' % (fp, expected)
 
     def test_load_der_string(self):
-        f = open('tests/x509.der', 'rb')
+        f = open('test/x509.der', 'rb')
         x509 = X509.load_cert_der_string(''.join(f.readlines()))
         fp = x509.get_fingerprint('sha1')
         expected = '7B8D34D23BF755BE23891AF4CAA0A9868F4C65AD'
         assert fp == expected, '%s != %s' % (fp, expected)
 
     def test_save_der_string(self):
-        x509 = X509.load_cert('tests/x509.pem')
+        x509 = X509.load_cert('test/x509.pem')
         s = x509.as_der()
-        f = open('tests/x509.der', 'rb')
+        f = open('test/x509.der', 'rb')
         s2 = f.read()
         f.close()
         assert s == s2
 
     def test_load(self):
-        x509 = X509.load_cert('tests/x509.pem')
-        x5092 = X509.load_cert('tests/x509.der', format=X509.FORMAT_DER)
+        x509 = X509.load_cert('test/x509.pem')
+        x5092 = X509.load_cert('test/x509.der', format=X509.FORMAT_DER)
         assert x509.as_text() == x5092.as_text()
         assert x509.as_pem() == x5092.as_pem()
         assert x509.as_der() == x5092.as_der()
         return
     
     def test_load_bio(self):
-        bio = BIO.openfile('tests/x509.pem')
-        bio2 = BIO.openfile('tests/x509.der')
+        bio = BIO.openfile('test/x509.pem')
+        bio2 = BIO.openfile('test/x509.der')
         x509 = X509.load_cert_bio(bio)
         x5092 = X509.load_cert_bio(bio2, format=X509.FORMAT_DER)
         
@@ -380,10 +380,10 @@ class X509TestCase(unittest.TestCase):
         return
 
     def test_load_string(self):
-        f = open('tests/x509.pem')
+        f = open('test/x509.pem')
         s = f.read()
         f.close()
-        f2 = open('tests/x509.der', 'rb')
+        f2 = open('test/x509.der', 'rb')
         s2 = f2.read()
         f2.close()
         x509 = X509.load_cert_string(s)
@@ -409,47 +409,47 @@ class X509TestCase(unittest.TestCase):
         self.assertRaises(ValueError, X509.load_request_bio, BIO.MemoryBuffer(req.as_pem()), 345678)
 
     def test_save(self):
-        x509 = X509.load_cert('tests/x509.pem')
+        x509 = X509.load_cert('test/x509.pem')
         x509_pem = x509.as_pem()
-        f = open('tests/x509.der', 'rb')
+        f = open('test/x509.der', 'rb')
         x509_der = f.read()
         f.close()
-        x509.save('tests/tmpcert.pem')
-        f = open('tests/tmpcert.pem')
+        x509.save('test/tmpcert.pem')
+        f = open('test/tmpcert.pem')
         s = f.read()
         f.close()
         self.assertEquals(s, x509_pem)
-        os.remove('tests/tmpcert.pem')
-        x509.save('tests/tmpcert.der', format=X509.FORMAT_DER)
-        f = open('tests/tmpcert.der', 'rb')
+        os.remove('test/tmpcert.pem')
+        x509.save('test/tmpcert.der', format=X509.FORMAT_DER)
+        f = open('test/tmpcert.der', 'rb')
         s = f.read()
         f.close()
         self.assertEquals(s, x509_der)
-        os.remove('tests/tmpcert.der')
+        os.remove('test/tmpcert.der')
 
     def test_malformed_data(self):
         self.assertRaises(X509.X509Error, X509.load_cert_string, 'Hello')
         self.assertRaises(X509.X509Error, X509.load_cert_der_string, 'Hello')
         self.assertRaises(X509.X509Error, X509.new_stack_from_der, 'Hello')
-        self.assertRaises(X509.X509Error, X509.load_cert, 'tests/alltests.py')
-        self.assertRaises(X509.X509Error, X509.load_request, 'tests/alltests.py')
+        self.assertRaises(X509.X509Error, X509.load_cert, 'test/alltests.py')
+        self.assertRaises(X509.X509Error, X509.load_request, 'test/alltests.py')
         self.assertRaises(X509.X509Error, X509.load_request_string, 'Hello')
         self.assertRaises(X509.X509Error, X509.load_request_der_string, 'Hello')
-        self.assertRaises(X509.X509Error, X509.load_crl, 'tests/alltests.py')
+        self.assertRaises(X509.X509Error, X509.load_crl, 'test/alltests.py')
         
     def test_long_serial(self):
         from M2Crypto import X509
-        cert = X509.load_cert('tests/long_serial_cert.pem')
+        cert = X509.load_cert('test/long_serial_cert.pem')
         self.assertEquals(cert.get_serial_number(), 17616841808974579194)
 
-        cert = X509.load_cert('tests/thawte.pem')
+        cert = X509.load_cert('test/thawte.pem')
         self.assertEquals(cert.get_serial_number(), 127614157056681299805556476275995414779)
 
 
 class X509_StackTestCase(unittest.TestCase):
     
     def test_make_stack_from_der(self):
-        f = open("tests/der_encoded_seq.b64")
+        f = open("test/der_encoded_seq.b64")
         b64 = f.read(1304)
         seq = base64.decodestring(b64)
         stack = X509.new_stack_from_der(seq)
@@ -463,7 +463,7 @@ class X509_StackTestCase(unittest.TestCase):
         assert str(subject) == "/DC=org/DC=doegrids/OU=Services/CN=host/bosshog.lbl.gov"
 
     def test_make_stack_check_num(self):
-        f = open("tests/der_encoded_seq.b64")
+        f = open("test/der_encoded_seq.b64")
         b64 = f.read(1304)
         seq = base64.decodestring(b64)
         stack = X509.new_stack_from_der(seq)
@@ -477,8 +477,8 @@ class X509_StackTestCase(unittest.TestCase):
 
     def test_make_stack(self):
         stack = X509.X509_Stack()
-        cert = X509.load_cert("tests/x509.pem")
-        issuer = X509.load_cert("tests/ca.pem")
+        cert = X509.load_cert("test/x509.pem")
+        issuer = X509.load_cert("test/ca.pem")
         cert_subject1 = cert.get_subject()
         issuer_subject1 = issuer.get_subject()
         stack.push(cert)
@@ -500,8 +500,8 @@ class X509_StackTestCase(unittest.TestCase):
     
     def test_as_der(self):
         stack = X509.X509_Stack()
-        cert = X509.load_cert("tests/x509.pem")
-        issuer = X509.load_cert("tests/ca.pem")
+        cert = X509.load_cert("test/x509.pem")
+        issuer = X509.load_cert("test/ca.pem")
         cert_subject1 = cert.get_subject()
         issuer_subject1 = issuer.get_subject()
         stack.push(cert)


### PR DESCRIPTION
I would argue this pull request supercedes #20 which includes an unnecessary `.idea/` directry and #58 which changes over 1000 unrelated lines. 

Following this patch 2 failing tests and 1 error are left:
```
======================================================================
ERROR: test_use_weak_cipher (test.test_ssl.MiscSSLClientTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/alex/src/m2crypto/test/test_ssl.py", line 418, in test_use_weak_cipher
    s.connect(self.srv_addr)
  File "/home/alex/src/m2crypto/M2Crypto/SSL/Connection.py", line 179, in connect
    ret = self.connect_ssl()
  File "/home/alex/src/m2crypto/M2Crypto/SSL/Connection.py", line 172, in connect_ssl
    return m2.ssl_connect(self.ssl)
SSLError: sslv3 alert handshake failure

======================================================================
FAIL: test_x509_name (test.test_x509.X509TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/alex/src/m2crypto/test/test_x509.py", line 145, in test_x509_name
    assert n.as_hash() == 1697185131
AssertionError

======================================================================
FAIL: test_tls1_nok (test.test_ssl.MiscSSLClientTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/alex/src/m2crypto/test/test_ssl.py", line 345, in test_tls1_nok
    self.failUnlessEqual(e[0], 'wrong version number')
AssertionError: 'unexpected eof' != 'wrong version number'

----------------------------------------------------------------------
Ran 231 tests in 42.526s

FAILED (failures=2, errors=1)
```