### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/M2Crypto/AuthCookie.py
+++ b/M2Crypto/AuthCookie.py
@@ -57,7 +57,7 @@ class AuthCookieJar:
             and (c.output() == cookie.output())
 
     def isGoodCookieString(self, cookie_str):
-        c = Cookie.SmartCookie()        
+        c = Cookie.SimpleCookie()        
         c.load(cookie_str)
         if not c.has_key(_TOKEN):
             return 0
@@ -75,7 +75,7 @@ class AuthCookie:
         self._expiry = expiry
         self._data = data
         self._mac = mac
-        self._cookie = Cookie.SmartCookie()
+        self._cookie = Cookie.SimpleCookie()
         self._cookie[_TOKEN] = '%s%s' % (dough, mac)
         self._name = '%s%s' % (dough, mac)  # XXX WebKit only.
 


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
For example, the following cookie header would shutdown your server/client:
Set-Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."