### PR TITLE
Fix NameError: m for invalid dates

### DIFF
--- a/M2Crypto/ASN1.py
+++ b/M2Crypto/ASN1.py
@@ -174,7 +174,7 @@ class ASN1_UTCTIME:
             raise ValueError("Invalid date: %s" % date)
         month, rest = date.split(' ', 1)
         if month not in self._ssl_months:
-            raise ValueError("Invalid date %s: Invalid month: %s" % (date, m))
+            raise ValueError("Invalid date %s: Invalid month: %s" % (date, month))
         if rest.endswith(' GMT'):
             timezone = UTC
             rest = rest[:-4]


### PR DESCRIPTION
Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/M2Crypto/ASN1.py", line 177, in get_datetime
raise ValueError("Invalid date %s: Invalid month: %s" % (date, m))
NameError: global name 'm' is not defined